### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "echo building... && typings bundle -o out",
+    "build": "echo building... && typings bundle -o out/index.d.ts",
     "lint": "echo linting... && tslint \"**/*.ts\" -e \"node_modules/**\" -e \"source/**\"  -e \"source-test/**\" -e \"out/**\" -e \"typings/**\"",
     "test": "echo testing... && cd test && ts-node ../node_modules/blue-tape/bin/blue-tape \"**/*.ts\" | tap-spec",
     "source-test": "echo source-testing... && echo no source-test configured",
@@ -15,12 +15,12 @@
   "devDependencies": {
     "blue-tape": "^0.2.0",
     "es6-promise": "^3.1.2",
-    "onchange": "^2.4.0",
+    "onchange": "^2.5.0",
     "tap-spec": "^4.1.1",
-    "ts-node": "^0.7.2",
-    "tslint": "^3.7.4",
+    "ts-node": "^0.7.3",
+    "tslint": "^3.10.2",
     "tslint-config-typings": "^0.2.3",
     "typescript": "^1.8.10",
-    "typings": "^0.7.12"
+    "typings": "^1.0.4"
   }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,8 +4,8 @@
     "moduleResolution": "node"
   },
   "files": [
-    "../typings/main.d.ts",
-    "../out/main.d.ts",
+    "../typings/index.d.ts",
+    "../out/index.d.ts",
     "test.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "files": [
-    "typings/main.d.ts",
+    "typings/index.d.ts",
     "index.d.ts"
   ]
 }

--- a/typings.json
+++ b/typings.json
@@ -2,11 +2,11 @@
   "name": "blue-tape",
   "main": "index.d.ts",
   "version": "0.2.0",
-  "ambientDependencies": {
-    "node": "registry:dt/node#4.0.0+20160412142033"
-  },
   "dependencies": {
     "es6-promise": "registry:npm/es6-promise#3.0.0+20160211003958",
-    "tape": "registry:npm/tape#4.0.0+20160322235547"
+    "tape": "registry:npm/tape#4.0.0+20160607230938"
+  },
+  "globalDependencies": {
+    "node": "registry:env/node#4.0.0+20160507210304"
   }
 }


### PR DESCRIPTION
Something a little strange is when I run `npm i`, it produces:

``` sh
npm i

> undefined prepublish /Users/hwong/github/typed-typings/npm-blue-tape
> typings install


├── es6-promise
├── tape
└── node@4 (global)
```

Notice there are the undefined prepublish and there are two blank lines from `> typings install` to the tree.

Besides that, things are fine.
